### PR TITLE
Small fix-ups for NobleJS/setImmediate

### DIFF
--- a/setImmediate.js
+++ b/setImmediate.js
@@ -18,16 +18,16 @@ if (!window.setImmediate) {
 		var attachTo = typeof Object.getPrototypeOf === "function" ? Object.getPrototypeOf(window) : window;
 
 		if (window.postMessage) { // For modern browsers.
-			var handle = 1, // Handle MUST be non-zero, says the spec.
-			    immediates = [],
-			    messageName = "com.bn.NobleJS.setImmediate",
-			    executeTask = function(task) {
+			var handle = 1; // Handle MUST be non-zero, says the spec.
+	 	 	var immediates = [];
+			var messageName = "com.bn.NobleJS.setImmediate";
+			function executeTask(task) {
 				if (task.handler.apply) {
 					task.handler.apply(task.that, task.args);
 				} else {
 					throw new Error("setImmediate.js: shoot me now! there's no way I'm implementing an evaluated handler!");
 				}
-			    };
+			}
 
 			function handleMessage(event) {
 				if (event.source === window && event.data === messageName) {
@@ -46,9 +46,9 @@ if (!window.setImmediate) {
 			}
 
 			attachTo.setImmediate = function (/*handler[, args]*/) {
-				var handler = arguments[0],
-				    args = [].slice.call(arguments, 1),
-				    task = { handle: handle, handler: handler, args: args, that: this };
+				var handler = arguments[0];
+				var args = [].slice.call(arguments, 1);
+				var task = { handle: handle, handler: handler, args: args, that: this };
 				immediates.push(task);
 				window.postMessage(messageName, "*");
 				return handle++;
@@ -64,9 +64,9 @@ if (!window.setImmediate) {
 			};
 		} else { // Fallback to legacy support for non-postMessage browsers.
 			attachTo.setImmediate = function (/*handler[, args]*/) {
-				var that = this,
-				    handler = arguments[0],
-				    args = [].slice.call(arguments, 1);
+				var that = this;
+			 	var handler = arguments[0];
+				var args = [].slice.call(arguments, 1);
 				return setTimeout(function () {
 					executeTask({ handler:handler, args: args, that: that });
 				}, 0);


### PR DESCRIPTION
Hi Domenic. I've looked at your implementation of cross-browser setImmediate, and I like it a lot (and would like to use it for some of my projects), but there are a few points relating to code correctness that I would like to address before using this implementation. 

I'd appreciate it you can go over my edits and comment on them. Thanks in advance :-)
- de-duplicate task execution: the actual calling of the handler is identical in both the postMessage implementation and the fallback, so I figured de-duping them is probably a good idea.
- use attachTo also in fallback: I didn't understand why you resolve "attachTo" at the top level, but then don't use it in the fallback - so I added that.
- removed multiple var keywords: http://www.jslint.com/lint.html#scope and http://stackoverflow.com/questions/694102/declaring-multiple-variables-in-javascript 
