### PR TITLE
adding catch for IE10's implementation

### DIFF
--- a/setImmediate.js
+++ b/setImmediate.js
@@ -17,7 +17,10 @@ if (!window.setImmediate) {
 		// If supported, we should attach to the prototype of window, since that is where setTimeout et al. live.
 		var attachTo = typeof Object.getPrototypeOf === "function" ? Object.getPrototypeOf(window) : window;
 
-		if (window.postMessage) { // For modern browsers.
+		if (window.msSetImmediate && window.msClearImmediate) {
+			attachTo.setImmediate = window.msSetImmediate;
+			attachTo.clearImmediate = window.msClearImmediate;
+		} else if (window.postMessage) { // For modern browsers.
 			var handle = 1; // Handle MUST be non-zero, says the spec.
 	 	 	var immediates = [];
 			var messageName = "com.bn.NobleJS.setImmediate";


### PR DESCRIPTION
IE uses the ms prefix, source: http://msdn.microsoft.com/en-us/ie/hh272906.aspx
