### PR TITLE
Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+    "name": "setimmediate",
+    "version": "1.0.1",
+    "main": "setImmediate.js",
+    "ignore": [
+        ".*",
+        "package.json",
+        "qUnitTest/",
+        "test/"
+    ]
+}


### PR DESCRIPTION
It looks like this repo was registered as the main `setImmediate` polyfill on bower. Though it doesn't seem to have a `bower.json`. If you don't know what this is, you may have not of registered it, maybe someone else did.

```
$ bower search setimmediate
Search results:

    setimmediate git://github.com/NobleJS/setImmediate.git
```

I'd love to see this package get a proper bower config file. But if you have no interest, I could setup a mirror under https://github.com/components and maintain it myself.

/cc @domenic
