### PR TITLE
Add commonjs support

### DIFF
--- a/setImmediate.js
+++ b/setImmediate.js
@@ -215,4 +215,8 @@
 
         attachTo.clearImmediate = tasks.remove;
     }
+    
+    if (typeof module !== 'undefined') {
+        module.exports = global.setImmediate;
+    }
 }(typeof global === "object" && global ? global : this));


### PR DESCRIPTION
Allows for

`var setImmediate = require("setimmediate")`

In both node & browserify
