### PR TITLE
In an environment that provides modules.export - use it

### DIFF
--- a/setImmediate.js
+++ b/setImmediate.js
@@ -2,6 +2,12 @@
     "use strict";
 
     if (global.setImmediate) {
+        if (module) {
+            module.exports = {
+                setImmediate: global.setImmediate,
+                clearImmediate: global.clearImmediate
+            };
+        }
         return;
     }
 
@@ -172,4 +178,11 @@
 
     attachTo.setImmediate = setImmediate;
     attachTo.clearImmediate = clearImmediate;
+
+    if (module) {
+        module.exports = {
+            setImmediate: setImmediate,
+            clearImmediate: clearImmediate
+        };
+    }
 }(typeof self === "undefined" ? typeof global === "undefined" ? this : global : self));

--- a/test/tests.js
+++ b/test/tests.js
@@ -15,7 +15,7 @@ if (originalGlobalSetImmediate) {
 }
 
 var assert = require("assert");
-require("../setImmediate");
+var sI = require("../setImmediate");
 
 specify("Handlers do execute", function (done) {
     setImmediate(function () {
@@ -103,4 +103,10 @@ specify("`clearImmediate` does not interfere with handlers other than the one wi
         assert.deepEqual(recordedArgs, expectedArgs);
         done();
     }, 100);
+});
+
+specify("Returns an object with proper functions.", function() {
+    assert(typeof sI === "object")
+    assert(typeof sI.setImmediate === "function");
+    assert(typeof sI.clearImmediate === "function");
 });


### PR DESCRIPTION
I was running into some issues using Karma, Mocha, and Browserify - it works perfectly in an a user browser, but in PhantomJS setImmediate failed to initialize itself.  Returning the generated functions via module.exports in a node/browserify environment provides greater flexibility in usage without breaking old functionality.