### PR TITLE
Add Promise-based implementation

### DIFF
--- a/setImmediate.js
+++ b/setImmediate.js
@@ -9,24 +9,21 @@
     var tasksByHandle = {};
     var currentlyRunningATask = false;
     var doc = global.document;
-    var setImmediate;
+    var registerImmediate;
 
-    function addFromSetImmediateArguments(args) {
-        tasksByHandle[nextHandle] = partiallyApplied.apply(undefined, args);
-        return nextHandle++;
-    }
-
-    // This function accepts the same arguments as setImmediate, but
-    // returns a function that requires no arguments.
-    function partiallyApplied(handler) {
-        var args = [].slice.call(arguments, 1);
-        return function() {
-            if (typeof handler === "function") {
-                handler.apply(undefined, args);
-            } else {
-                (new Function("" + handler))();
-            }
-        };
+    function setImmediate(callback) {
+      // Callback can either be a function or a string
+      if (typeof callback !== 'function')
+        callback = new Function('' + callback);
+      // Copy function arguments
+      var args = new Array(arguments.length - 1);
+      for (var i = 0; i < args.length; i++)
+          args[i] = arguments[i + 1];
+      // Store and register the task
+      var task = { callback: callback, args: args };
+      tasksByHandle[nextHandle] = task;
+      registerImmediate(nextHandle);
+      return nextHandle++;
     }
 
     function runIfPresent(handle) {
@@ -35,13 +32,13 @@
         if (currentlyRunningATask) {
             // Delay by doing a setTimeout. setImmediate was tried instead, but in Firefox 7 it generated a
             // "too much recursion" error.
-            setTimeout(partiallyApplied(runIfPresent, handle), 0);
+            setTimeout(function () { runIfPresent(handle); }, 0);
         } else {
             var task = tasksByHandle[handle];
             if (task) {
                 currentlyRunningATask = true;
                 try {
-                    task();
+                    run(task);
                 } finally {
                     clearImmediate(handle);
                     currentlyRunningATask = false;
@@ -50,15 +47,35 @@
         }
     }
 
+    function run(task) {
+        var callback = task.callback;
+        var args = task.args;
+        switch (args.length) {
+        case 0:
+            callback();
+            break;
+        case 1:
+            callback(args[0]);
+            break;
+        case 2:
+            callback(args[0], args[1]);
+            break;
+        case 3:
+            callback(args[0], args[1], args[2]);
+            break;
+        default:
+            callback.apply(undefined, args);
+            break;
+        }
+    }
+
     function clearImmediate(handle) {
         delete tasksByHandle[handle];
     }
 
     function installNextTickImplementation() {
-        setImmediate = function() {
-            var handle = addFromSetImmediateArguments(arguments);
-            process.nextTick(partiallyApplied(runIfPresent, handle));
-            return handle;
+        registerImmediate = function(handle) {
+            process.nextTick(function () { runIfPresent(handle); });
         };
     }
 
@@ -97,10 +114,8 @@
             global.attachEvent("onmessage", onGlobalMessage);
         }
 
-        setImmediate = function() {
-            var handle = addFromSetImmediateArguments(arguments);
+        registerImmediate = function(handle) {
             global.postMessage(messagePrefix + handle, "*");
-            return handle;
         };
     }
 
@@ -111,17 +126,14 @@
             runIfPresent(handle);
         };
 
-        setImmediate = function() {
-            var handle = addFromSetImmediateArguments(arguments);
+        registerImmediate = function(handle) {
             channel.port2.postMessage(handle);
-            return handle;
         };
     }
 
     function installReadyStateChangeImplementation() {
         var html = doc.documentElement;
-        setImmediate = function() {
-            var handle = addFromSetImmediateArguments(arguments);
+        registerImmediate = function(handle) {
             // Create a <script> element; its readystatechange event will be fired asynchronously once it is inserted
             // into the document. Do so, thus queuing up the task. Remember to clean up once it's been called.
             var script = doc.createElement("script");
@@ -132,15 +144,12 @@
                 script = null;
             };
             html.appendChild(script);
-            return handle;
         };
     }
 
     function installSetTimeoutImplementation() {
-        setImmediate = function() {
-            var handle = addFromSetImmediateArguments(arguments);
-            setTimeout(partiallyApplied(runIfPresent, handle), 0);
-            return handle;
+        registerImmediate = function(handle) {
+            setTimeout(function () { runIfPresent(handle); }, 0);
         };
     }
 

--- a/setImmediate.js
+++ b/setImmediate.js
@@ -79,6 +79,12 @@
         };
     }
 
+    function installPromiseImplementation() {
+        registerImmediate = function(handle) {
+            Promise.resolve(handle).then(runIfPresent);
+        };
+    }
+
     function canUsePostMessage() {
         // The test against `importScripts` prevents this implementation from being installed inside a web worker,
         // where `global.postMessage` means something completely different and can't be used for this purpose.
@@ -161,6 +167,10 @@
     if ({}.toString.call(global.process) === "[object process]") {
         // For Node.js before 0.9
         installNextTickImplementation();
+    } else if (typeof Promise === "function" && Promise.resolve &&
+               (Promise.resolve + "").indexOf("[native code]") > 0) {
+        // For modern browsers
+        installPromiseImplementation();
 
     } else if (canUsePostMessage()) {
         // For non-IE10 modern browsers


### PR DESCRIPTION
This pull request adds a `Promise`-based implementation of `setImmediate`. It builds upon #55, which was not merged yet, so only fb5129ceb4bae4957b3c261f1bb69cee08e89bef counts.

Ironically, `setImmediate` was often needed to implement promises; now we do the inverse.

**[Benchmark](https://gist.github.com/RubenVerborgh/a9240a4a0db280f597a16fc3ed5411bd#file-test-setimmediate-performance-browser-js)**

|                                                         | Chrome 52 (s) | Firefox 47 (s) | Safari 9.1.1 (s) |
|---------------------------------------------------------|-----------:|------------:|-----------------:|
| #55 |       26.6 |        22.3 |             14.1 |
| this pull request                                       |        5.5 |        10.3 |             2.1 |

