### PR TITLE
Function attachment failure in a case of freezed global object

### DIFF
--- a/setImmediate.js
+++ b/setImmediate.js
@@ -84,7 +84,7 @@
     function canUsePostMessage() {
         // The test against `importScripts` prevents this implementation from being installed inside a web worker,
         // where `global.postMessage` means something completely different and can't be used for this purpose.
-        if (global.postMessage && !global.importScripts) {
+        if (global.postMessage && !global.importScripts && !(global.port && global.port.emit)) {
             var postMessageIsAsynchronous = true;
             var oldOnMessage = global.onmessage;
             global.onmessage = function() {
@@ -183,4 +183,4 @@
 
     attachTo.setImmediate = setImmediate;
     attachTo.clearImmediate = clearImmediate;
-}(typeof self === "undefined" ? typeof global === "undefined" ? this : global : self));
+}(typeof self === "undefined" || !Object.isExtensible(self) ? typeof global === "undefined" || !Object.isExtensible(global) ? this : global : self));


### PR DESCRIPTION
This pull request aims to fix issue #58 that arises in a case if freezed global object is selected for patching. Such situation can arise e.g. in a case if script is running inside Firefox Add-on SDK based extension's content script (see for some more details [here](https://github.com/YuzuJS/setImmediate/issues/58#issuecomment-265473505)).

Tests are passed both in Node as well as in latest Chrome, Firefox and IE11.