### PR TITLE
Check that doc.createElement is defined

### DIFF
--- a/setImmediate.js
+++ b/setImmediate.js
@@ -172,7 +172,7 @@
         // For web workers, where supported
         installMessageChannelImplementation();
 
-    } else if (doc && "onreadystatechange" in doc.createElement("script")) {
+    } else if (doc && doc.createElement && "onreadystatechange" in doc.createElement("script")) {
         // For IE 6–8
         installReadyStateChangeImplementation();
 


### PR DESCRIPTION
In my runtime environment (Nativescript) it appears that `global.document` is defined but has no member `createElement`. Adding this extra check so that environments do not fail when `createElement` is not defined.