### PR TITLE
Install polyfill if clearImmediate is undefined

### DIFF
--- a/setImmediate.js
+++ b/setImmediate.js
@@ -1,7 +1,7 @@
 (function (global, undefined) {
     "use strict";
 
-    if (global.setImmediate) {
+    if (global.setImmediate && global.clearImmediate) {
         return;
     }
 


### PR DESCRIPTION
At JW Player we've found sites that have `setImmediate` polyfilled without `clearImmediate`. This breaks our player's embed because it's compiled with webpack which depends on this module as a sub-dependency.

Checking that both `setImmediate` and `clearImmediate` are defined before exiting ensures that the polyfill is always attached when needed.