### PR TITLE
Replace event.data.indexOf with faster loop

### DIFF
--- a/setImmediate.js
+++ b/setImmediate.js
@@ -96,6 +96,17 @@
         }
     }
 
+    function startsWith(string, value) {
+        for (var index = 0; index < value.length; index++) {
+            var stringChar = string[index]
+            var valueChar = value[index]
+
+            if (stringChar !== valueChar) return false
+        }
+
+        return true
+    }
+
     function installPostMessageImplementation() {
         // Installs an event handler on `global` for the `message` event: see
         // * https://developer.mozilla.org/en/DOM/window.postMessage
@@ -105,7 +116,7 @@
         var onGlobalMessage = function(event) {
             if (event.source === global &&
                 typeof event.data === "string" &&
-                event.data.indexOf(messagePrefix) === 0) {
+                startsWith(event.data, messagePrefix)) {
                 runIfPresent(+event.data.slice(messagePrefix.length));
             }
         };


### PR DESCRIPTION
As the event handler is attached to the global message event it is called for a lot of events. Searching through the whole string to not find the messagePrefix is quite slow.

This will only check if the string starts with the messagePrefix which is a lot faster.

https://jsperf.com/starts-with-indexof